### PR TITLE
gen_random_hex works across whole one-click-app YAML

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -158,6 +158,16 @@ class CaproverAPI:
         :return The updated raw app definiton with all variables resolved.
         """
         raw_app_data = raw_app_definition
+        # Replace any random hex generators in the raw data first
+        for match in re.finditer(r"\$\$cap_gen_random_hex\((\d+)\)", raw_app_data):
+            requested_length = int(match.group(1))
+            raw_app_data = raw_app_data.replace(
+                match.group(0),
+                # slice notation is because secrets.token_hex generates the hex
+                # representation of n bytes, which is twice as many hex chars.
+                secrets.token_hex(requested_length)[:requested_length]
+            )
+
         app_variables.update(
             {
                 "$$cap_appname": cap_app_name,
@@ -172,13 +182,6 @@ class CaproverAPI:
         for app_variable in variables:
             if app_variables.get(app_variable['id']) is None:
                 default_value = app_variable.get('defaultValue', '')
-                is_random_hex = re.search(
-                    r"\$\$cap_gen_random_hex\((\d+)\)", default_value or ""
-                )
-                if is_random_hex:
-                    default_value = secrets.token_hex(
-                        int(is_random_hex.group(1))
-                    )
                 is_valid = re.search(
                     app_variable.get('validRegex', '.*').strip('/'),
                     default_value

--- a/tests/test_caprover_api.py
+++ b/tests/test_caprover_api.py
@@ -2,8 +2,12 @@
 
 """Tests for `caprover_api` package."""
 
-
 import unittest
+from unittest.mock import patch
+
+import yaml
+
+from caprover_api.caprover_api import CaproverAPI
 
 
 class TestCaprover_api(unittest.TestCase):
@@ -17,3 +21,95 @@ class TestCaprover_api(unittest.TestCase):
 
     def test_000_something(self):
         """Test something."""
+
+
+class TestAppVariables(unittest.TestCase):
+    """Tests for app variable resolution in one-click-app definitions"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        with patch.object(CaproverAPI, "get_system_info"), patch.object(
+            CaproverAPI, "_login"
+        ):
+            self.api = CaproverAPI(
+                dashboard_url="http://dummy", password="dummy"
+            )
+            self.api.root_domain = (
+                "example.com"  # This is used by _resolve_app_variables
+            )
+        self.raw_yaml = """
+captainVersion: 4
+services:
+  $$cap_appname:
+    image: $$cap_docker_image
+    environment:
+      SECRET: $$cap_gen_random_hex(10)
+      VRD: $$cap_var_with_random_default
+      VSD: $$cap_var_with_static_default
+
+caproverOneClickApp:
+  variables:
+    - id: '$$cap_docker_image'
+      label: Docker Image
+    - id: '$$cap_var_with_random_default'
+      label: Var with random default
+      defaultValue: '$$cap_gen_random_hex(6)'
+    - id: '$$cap_var_with_static_default'
+      label: Var with static default
+      defaultValue: 'Abcde'
+"""
+
+    def test_appname_replacement(self):
+        """Test that $$cap_appname is replaced correctly"""
+        result = self.api._resolve_app_variables(
+            self.raw_yaml, "testapp", {}, automated=True
+        )
+        parsed = yaml.safe_load(result)
+        self.assertIn("testapp", parsed["services"])
+
+    def test_override_default(self):
+        """A defaultValue can be overridden by app_variables"""
+        result = self.api._resolve_app_variables(
+            self.raw_yaml,
+            "testapp",
+            {"$$cap_var_with_static_default": "CustomValue"},
+            automated=True,
+        )
+        parsed = yaml.safe_load(result)
+        self.assertEqual(
+            parsed["services"]["testapp"]["environment"]["VSD"], "CustomValue"
+        )
+
+    def test_static_default_variable(self):
+        """Variable with (static) defaultValue gets that value when not set"""
+        result = self.api._resolve_app_variables(
+            self.raw_yaml, "testapp", {}, automated=True
+        )
+        parsed = yaml.safe_load(result)
+        self.assertEqual(
+            parsed["services"]["testapp"]["environment"]["VSD"], "Abcde"
+        )
+
+    def test_gen_random_hex_default_variable(self):
+        """Variable with random default gets a random value when not set"""
+        result = self.api._resolve_app_variables(
+            self.raw_yaml, "testapp", {}, automated=True
+        )
+        parsed = yaml.safe_load(result)
+        # FIXME: The template requested 6 characters long,
+        # but it ends up being the hex equivalent of 6 bytes (= 12 ascii characters)
+        self.assertRegex(
+            parsed["services"]["testapp"]["environment"]["VRD"],
+            r"^[0-9a-f]{6}$",
+        )
+
+    def test_gen_random_hex_in_service(self):
+        """gen_random_hex is applied in service definitions (not just variables)"""
+        result = self.api._resolve_app_variables(
+            self.raw_yaml, "testapp", {}, automated=True
+        )
+        parsed = yaml.safe_load(result)
+        self.assertRegex(
+            parsed["services"]["testapp"]["environment"]["SECRET"],
+            r"^[0-9a-f]{10}$",
+        )

--- a/tests/test_caprover_api.py
+++ b/tests/test_caprover_api.py
@@ -97,7 +97,7 @@ caproverOneClickApp:
         )
         parsed = yaml.safe_load(result)
         self.assertRegex(
-            parsed["services"]["testapp"]["environment"]["VRD"],
+            str(parsed["services"]["testapp"]["environment"]["VRD"]),
             r"^[0-9a-f]{6}$",
         )
 

--- a/tests/test_caprover_api.py
+++ b/tests/test_caprover_api.py
@@ -96,8 +96,6 @@ caproverOneClickApp:
             self.raw_yaml, "testapp", {}, automated=True
         )
         parsed = yaml.safe_load(result)
-        # FIXME: The template requested 6 characters long,
-        # but it ends up being the hex equivalent of 6 bytes (= 12 ascii characters)
         self.assertRegex(
             parsed["services"]["testapp"]["environment"]["VRD"],
             r"^[0-9a-f]{6}$",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,5 @@ deps = flake8
 commands = flake8 caprover_api tests
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}
-
-commands = python setup.py test
+deps = pytest
+commands = pytest {posargs:tests}


### PR DESCRIPTION
This PR contains a couple improvements around the `$$cap_gen_random_hex(...)` replacement in one-click apps:

1. `gen_random_hex` now works across whole YAML, not only under the `caproverOneClickApp.variables` section.
2. `gen_random_hex(n)` generates $n$ ascii characters, not the hex representation of $n$ bytes. 

I confirmed both these behaviors now match what the Caprover frontend UI does.

Added a test suite around variable substitution, including bringing the tox invocation up-to-date.