### PR TITLE
update() now handles persistent directories that use hostPath

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -538,12 +538,19 @@ class CaproverAPI:
         :param app_name: name of the app you want to update
         :param instance_count: instances count, set 0 to stop the app
         :param captain_definition_path: captain-definition file relative path
-        :param environment_variables: dicts env variables
+        :param environment_variables: dict of env variables
+            will be merged with the current set:
+            There is no way to DELETE an env variable from this API.
         :param expose_as_web_app: set true to expose the app as web app
         :param force_ssl: force traffic to use ssl
         :param support_websocket: set to true to enable webhook support
         :param port_mapping: list of port mapping
-        :param persistent_directories: list
+        :param persistent_directories: list of dict
+            fields hostPath OR volumeName, containerPath
+            If a list is passed, it replaces the entire set of persistent
+              directories on the app.
+            Set to None (default) to leave as-is, or empty list to clear
+              existing mounts.
         :param container_http_port: port to use for your container app
         :param description: app description
         :param service_update_override: service override
@@ -575,24 +582,25 @@ class CaproverAPI:
         current_app_info['envVars'] = updated_environment_variables
 
         # handle volumes
-        # gets current volumes and overwrite with new data
-        current_volumes = current_app_info['volumes']
-        current_volumes_as_dict = {
-            item['volumeName']: item['containerPath'] for
-            item in current_volumes
-        }
-        if persistent_directories:
+        if persistent_directories is not None:
+            updated_volumes = []
             for volume_pair in persistent_directories:
                 volume_name, container_path = volume_pair.split(':')
-                current_volumes_as_dict[volume_name] = container_path
-        updated_volumes = [
-            {
-                "volumeName": volume_name,
-                "containerPath": container_path
-            } for
-            volume_name, container_path in current_volumes_as_dict.items()
-        ]
-        current_app_info['volumes'] = updated_volumes
+                if volume_name.startswith("/"):
+                    updated_volumes.append(
+                        {
+                            "hostPath": volume_name,
+                            "containerPath": container_path,
+                        }
+                    )
+                else:
+                    updated_volumes.append(
+                        {
+                            "volumeName": volume_name,
+                            "containerPath": container_path,
+                        }
+                    )
+            persistent_directories = updated_volumes
 
         if port_mapping:
             ports = [
@@ -612,6 +620,7 @@ class CaproverAPI:
             "forceSsl": force_ssl,
             "websocketSupport": support_websocket,
             "ports": ports,
+            "volumes": persistent_directories,
             "containerHttpPort": container_http_port,
             "description": description,
             "appPushWebhook": app_push_webhook,

--- a/tests/test_caprover_api.py
+++ b/tests/test_caprover_api.py
@@ -2,8 +2,11 @@
 
 """Tests for `caprover_api` package."""
 
-
+import json
 import unittest
+from unittest.mock import MagicMock, patch
+
+from caprover_api.caprover_api import CaproverAPI
 
 
 class TestCaprover_api(unittest.TestCase):
@@ -17,3 +20,111 @@ class TestCaprover_api(unittest.TestCase):
 
     def test_000_something(self):
         """Test something."""
+
+
+class TestUpdateApp(unittest.TestCase):
+    def setUp(self):
+        with patch.object(CaproverAPI, "get_system_info"), patch.object(
+            CaproverAPI, "_login"
+        ):
+            self.api = CaproverAPI(
+                dashboard_url="http://dummy", password="dummy"
+            )
+        self.api.headers = {"Authorization": "Bearer mock_token"}
+
+        # Mock session.post so we can sniff how update calls it
+        self.api.session = MagicMock()
+        self.api.session.post = MagicMock(
+            return_value=MagicMock(
+                json=lambda: {"description": "Saved", "status": 100}
+            )
+        )
+
+        # Mock get_app response to simulate the current app information
+        self.api.get_app = MagicMock(
+            return_value={
+                "appName": "test_app",
+                "envVars": [{"key": "EXISTING_ENV_VAR", "value": "old_value"}],
+                "volumes": [
+                    {
+                        "hostPath": "/old_path",
+                        "containerPath": "/container_path",
+                    }
+                ],
+                "appPushWebhook": {},
+            }
+        )
+
+    def test_add_environment_variables(self):
+        self.api.update_app(
+            "test_app",
+            environment_variables={"ANOTHER": "foobar"},
+        )
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        expected = [
+            {"key": "EXISTING_ENV_VAR", "value": "old_value"},
+            {"key": "ANOTHER", "value": "foobar"},
+        ]
+        self.assertEqual(post_data["envVars"], expected)
+
+    def test_update_no_change(self):
+        """
+        update_app, without passing persistent_directories arg, should
+        keep existing volumes from get_app.
+        """
+        self.api.update_app("test_app")
+
+        # Capture post data
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        # Assert 'volumes' is unchanged from get_app()
+        expected_volumes = [
+            {"hostPath": "/old_path", "containerPath": "/container_path"}
+        ]
+        self.assertEqual(post_data["volumes"], expected_volumes)
+
+    def test_update_with_persistent_directories_host_path(self):
+        """
+        Test update_app with persistent_directories using hostPath format.
+        """
+        self.api.update_app(
+            "test_app",
+            persistent_directories=["/new_host_path:/new_container_path"],
+        )
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        # Assert 'volumes' is replaced
+        expected_volumes = [
+            {
+                "hostPath": "/new_host_path",
+                "containerPath": "/new_container_path",
+            }
+        ]
+        self.assertEqual(post_data["volumes"], expected_volumes)
+
+    def test_update_with_persistent_directories_volume_name(self):
+        """
+        Test update_app with persistent_directories using volumeName format.
+        """
+        self.api.update_app(
+            "test_app",
+            persistent_directories=["new_volume:/new_container_path"],
+        )
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        # Assert 'volumes' is replaced with the new volumeName entry
+        expected_volumes = [
+            {"volumeName": "new_volume", "containerPath": "/new_container_path"}
+        ]
+        self.assertEqual(post_data["volumes"], expected_volumes)
+
+    def test_update_port_mapping(self):
+        self.api.update_app("test_app", port_mapping=["8080:80", "443:443"])
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        expected = [
+            {"containerPort": "80", "hostPort": "8080"},
+            {"containerPort": "443", "hostPort": "443"},
+        ]
+        self.assertEqual(post_data["ports"], expected)


### PR DESCRIPTION
update() now handles persistent directories that use `"hostPath"`.  Previously it only worked for `"volumeName"`.

BREAKING: we no longer attempt to merge current volumes with new ones, since that is hit-or-miss. (For example it wasn't possible to clear volumes before).  The new behavior mimics the behavior of `ports`.
New behavior:
- set `persistent_directories=None` (or do not pass it) to leave current directories as-is
- set `persistent_directories=[...]` to entirely replace the set of persistent directories (including clearing the set by passing an empty list)

