### PR TITLE
Bugfix: update() should not change notExposeAsWebApp

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -608,7 +608,7 @@ class CaproverAPI:
             "instanceCount": instance_count,
             "preDeployFunction": pre_deploy_function,
             "captainDefinitionRelativeFilePath": captain_definition_path,
-            "notExposeAsWebApp": not expose_as_web_app,
+            "notExposeAsWebApp": None if expose_as_web_app is None else (not expose_as_web_app),
             "forceSsl": force_ssl,
             "websocketSupport": support_websocket,
             "ports": ports,


### PR DESCRIPTION
Fixes a bug where calls to `update()` would inadvertently set `notExposeAsWebApp` to true, even if `update` was not called with `expose_as_webapp` as an arg.

The confusion was due to `not None == True`.

The solution is to explicitly check for None (as opposed to any falsey value)