### PR TITLE
Fix & test "update" from novel kwargs

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -647,11 +647,14 @@ class CaproverAPI:
                 continue
             # update current value with new value
             current_app_info[k] = v
-        kwargs.update(current_app_info)
+
+        # Any other kwarg is an automatic override.
+        current_app_info.update(kwargs)
+
         logging.info("{} | Updating app info...".format(app_name))
         response = self.session.post(
             self._build_url(CaproverAPI.UPDATE_APP_PATH),
-            headers=self.headers, data=json.dumps(kwargs)
+            headers=self.headers, data=json.dumps(current_app_info)
         )
         return CaproverAPI._check_errors(response.json())
 

--- a/tests/test_caprover_api.py
+++ b/tests/test_caprover_api.py
@@ -123,6 +123,7 @@ class TestUpdateApp(unittest.TestCase):
         self.api.get_app = MagicMock(
             return_value={
                 "appName": "test_app",
+                "redirectDomain": "",
                 "envVars": [{"key": "EXISTING_ENV_VAR", "value": "old_value"}],
                 "volumes": [
                     {
@@ -207,3 +208,11 @@ class TestUpdateApp(unittest.TestCase):
             {"containerPort": "443", "hostPort": "443"},
         ]
         self.assertEqual(post_data["ports"], expected)
+
+    def test_update_via_unspecified_kwarg(self):
+        """You can use kwargs to override any other not explicitly listed as a method arg."""
+        new_redirect_domain = "test_app.example.com"
+        self.api.update_app("test_app", redirectDomain=new_redirect_domain)
+        post_data = json.loads(self.api.session.post.call_args[1]["data"])
+
+        self.assertEqual(post_data["redirectDomain"], new_redirect_domain)


### PR DESCRIPTION
This PR allows you to use kwargs in your call to `update` to override any other property not explicitly listed as a method argument.  For example the new test illustrates passing `redirectDomain` (accepted by the underlying HTTP API) to set redirect domain, even though `update` does not explicitly specify support for it. This is a nice "escape hatch" that prevents the Caprover-API library from being the bottleneck for new features that get added to the HTTP API.

@ak4zh I'd love your thoughts on this because it somewhat undoes your previous commit https://github.com/ak4zh/Caprover-API/commit/0f6ab63a561cf7fe543251077b5c3729472ef56d .. I don't have the context around that commit to know if I might be breaking something.