### PR TITLE
One click app - custom name and tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,6 @@ automated deploy::
     }
     cap.deploy_one_click_app(
         one_click_app_name='redis',
-        namespace='new-app',
         app_variables=app_variables,
         automated=True
     )
@@ -73,8 +72,14 @@ automated deploy::
 manual deploy (you will be asked to enter required variables during runtime)::
 
     cap.deploy_one_click_app(
+        one_click_app_name='redis'
+    )
+
+rename app (to install under a different name than the name in the one-click repo)::
+
+    cap.deploy_one_click_app(
         one_click_app_name='redis',
-        namespace='new-app',
+        app_name='cache'
     )
 
 

--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -258,16 +258,16 @@ class CaproverAPI:
         return {}
 
     def deploy_one_click_app(
-        self, one_click_app_name: str, namespace: str,
+        self, one_click_app_name: str, app_name: str = None,
         app_variables: dict = None, automated: bool = False,
         one_click_repository: str = PUBLIC_ONE_CLICK_APP_PATH
     ):
         """
         Deploys a one-click app on the CapRover platform.
 
-        :param one_click_app_name: one click app name
-        :param namespace: a namespace to use for all services
-            inside the one-click app
+        :param one_click_app_name: one click app name in the repository
+        :param app_name: The name under which the app will be installed.
+            (optional) If unset, the `one_click_app_name` will be used.
         :param app_variables: dict containing required app variables
         :param automated: set to true
             if you have supplied all required variables
@@ -275,13 +275,14 @@ class CaproverAPI:
         :return dict containing the deployment "status" and "description".
         """
         app_variables = app_variables or {}
-        cap_app_name = "{}-{}".format(namespace, one_click_app_name)
+        if not app_name:
+            app_name = one_click_app_name
         raw_app_definition = self._download_one_click_app_defn(
             one_click_repository, one_click_app_name
         )
         resolved_app_data = self._resolve_app_variables(
             raw_app_definition=raw_app_definition,
-            cap_app_name=cap_app_name,
+            cap_app_name=app_name,
             app_variables=app_variables,
             automated=automated
         )

--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -258,9 +258,12 @@ class CaproverAPI:
         return {}
 
     def deploy_one_click_app(
-        self, one_click_app_name: str, app_name: str = None,
-        app_variables: dict = None, automated: bool = False,
-        one_click_repository: str = PUBLIC_ONE_CLICK_APP_PATH
+        self,
+        one_click_app_name: str,
+        app_name: str = None,
+        app_variables: dict = None,
+        automated: bool = False,
+        one_click_repository: str = PUBLIC_ONE_CLICK_APP_PATH,
     ):
         """
         Deploys a one-click app on the CapRover platform.
@@ -303,6 +306,8 @@ class CaproverAPI:
                         )
                     )
                     continue
+
+                tags = [{"tagName": app_name}]
                 has_persistent_data = bool(service_data.get("volumes"))
                 persistent_directories = service_data.get("volumes", [])
                 environment_variables = service_data.get("environment", {})
@@ -326,7 +331,8 @@ class CaproverAPI:
                     persistent_directories=persistent_directories,
                     environment_variables=environment_variables,
                     expose_as_web_app=expose_as_web_app,
-                    container_http_port=container_http_port
+                    container_http_port=container_http_port,
+                    tags=tags,
                 )
                 image_name = service_data.get("image")
                 docker_file_lines = caprover_extras.get("dockerfileLines")

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,7 +24,6 @@ automated deploy::
     }
     cap.deploy_one_click_app(
         one_click_app_name='redis',
-        namespace='new-app',
         app_variables=app_variables,
         automated=True
     )
@@ -33,8 +32,14 @@ automated deploy::
 manual deploy (you will be asked to enter required variables during runtime)::
 
     cap.deploy_one_click_app(
+        one_click_app_name='redis'
+    )
+
+rename app (to install under a different name than the name in the one-click repo)::
+
+    cap.deploy_one_click_app(
         one_click_app_name='redis',
-        namespace='new-app',
+        app_name='cache'
     )
 
 


### PR DESCRIPTION
This PR deals with assigning a custom name & tag when installing one-click apps.  In particular, bringing the python client's behavior more in-line with the caprover-frontend.


> ![Screenshot from 2024-12-13 15-55-36](https://github.com/user-attachments/assets/3fb7eb63-2d84-42b4-8342-e6c635e9bac3)


**1. Custom app names**
Previously: You had to deploy under the same name of the one-click app. There was no way to override `$$cap_appname`, which, by contrast, is allowed (required) when using the caprover frontend.
Now: Optionally pass `app_name`, as in `deploy_one_click_app(one_click_app_name='redis', app_name='mycache')`, to set a custom `$$cap_appname`.

**2. Drop `namespace`**
Previously: `deploy_one_click_app()` took `namespace`, which was prefixed to the one-click-app name no matter what:
Now: No prefixing. The names given in the one-click app YAML definition are what gets deployed.  I did this because it is not something that is done in the frontend at all.  Instead, related services will be grouped with tag, see below.
**THIS IS A BREAKING CHANGE** because it removes the `namespace` kwarg.  If you want to continue with the `
`"namespace-"` prefix, you can just set `app_name="namespace-redis"`, see above.
    - I updated the docs but will require re-deploying them.

**3. Tagging related services**
This PR assigns a Caprover **tag** to every service deployed in a one-click app. This is helpful to group the related services.  The tag is the one-click-app name: as is done by the frontend.
