### PR TITLE
Bump version: 0.1.23 → 0.1.24

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 History
 =======
 
+0.1.24 (2024-12-16)
+-------------------
+
+* Fix & test update from novel kwargs (#12)
+* update method lets you set httpAuth (#11)
+* `update()` now handles persistent directories that use hostPath (#7)
+* `gen_random_hex` works across whole one-click-app YAML (#6)
+* Bugfix: `update()` should not change notExposeAsWebApp (#8)
+* Enable SSL on base domain (#9)
+* Allow optional override one-click repository path (#5)
+
 0.1.0 (2021-06-11)
 ------------------
 

--- a/caprover_api/__init__.py
+++ b/caprover_api/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Akash Agarwal"""
 __email__ = 'agwl.akash@gmail.com'
-__version__ = '0.1.22'
+__version__ = '0.1.24'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.22
+current_version = 0.1.24
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ak4zh/caprover-api',
-    version='0.1.22',
+    version='0.1.24',
     zip_safe=False,
 )


### PR DESCRIPTION
@ak4zh I'm wondering if you can release new package versions of Caprover-API to pypi.  Here's what I propose:

## 0.1.24

Upon merging this PR.

Changelog
* Fix & test update from novel kwargs (#12)
* update method lets you set httpAuth (#11)
* `update()` now handles persistent directories that use hostPath (#7)
* `gen_random_hex` works across whole one-click-app YAML (#6)
* Bugfix: `update()` should not change notExposeAsWebApp (#8)
* Enable SSL on base domain (#9)
* Allow optional override one-click repository path (#5)

## 0.2.0

After merging #14, which contains breaking changes and updated docs.  (I can merge that or you can; it's ready to go)

Changelog
* One click app - custom name and tag

And 0.2.0 will also require updating readthedocs.