### PR TITLE
Override of one-click-app tag name; explicit support for update_app(tags=...)

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -305,6 +305,7 @@ class CaproverAPI:
         app_variables: dict = None,
         automated: bool = False,
         one_click_repository: str = PUBLIC_ONE_CLICK_APP_PATH,
+        tags: list[str] = None,
     ):
         """
         Deploys a one-click app on the CapRover platform.
@@ -316,11 +317,19 @@ class CaproverAPI:
         :param automated: set to true
             if you have supplied all required variables
         :param one_click_repository: where to download the one-click app from
+        :param tags: list of tags to apply to all services
+            (optional) If unset (None), a tag with the app_name will be used.
+            Pass an empty list to create no tags.
         :return dict containing the deployment "status" and "description".
         """
         app_variables = app_variables or {}
         if not app_name:
             app_name = one_click_app_name
+
+        # Default tag is the app_name if no custom tags provided
+        if tags is None:
+            tags = [app_name]
+
         raw_app_definition = self._download_one_click_app_defn(
             one_click_repository, one_click_app_name
         )
@@ -348,7 +357,6 @@ class CaproverAPI:
                     )
                     continue
 
-                tags = [{"tagName": app_name}]
                 has_persistent_data = bool(service_data.get("volumes"))
                 persistent_directories = service_data.get("volumes", [])
                 environment_variables = service_data.get("environment", {})
@@ -617,6 +625,7 @@ class CaproverAPI:
         app_push_webhook: dict = None,
         repo_info: dict = None,
         http_auth: dict = None,
+        tags: list[str] = None,
         **kwargs,
     ):
         """
@@ -646,6 +655,11 @@ class CaproverAPI:
             fields repo, user, password, sshKey, branch
         :param http_auth: dict with http auth info
             fields user, password
+        :param tags: list of strings to set as the app tags, allowing to better
+            group and view your apps in the table.
+            If a list is passed, it replaces the entire set of tags on the app.
+            Set to None (default) to leave tags as-is,
+            or pass an empty list to clear existing tags.
         :return: dict
         """
         current_app_info = self.get_app(app_name=app_name)
@@ -715,6 +729,7 @@ class CaproverAPI:
             "appPushWebhook": app_push_webhook,
             "serviceUpdateOverride": service_update_override,
             "httpAuth": http_auth,
+            "tags": None if tags is None else [{"tagName": t} for t in tags],
         }
         for k, v in _data.items():
             if v is None:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -107,7 +107,7 @@ add environment variables and volumes to app::
         persistent_directories=persistent_directories
     )
 
-add environment variables and volumes to app::
+add environment variables and volumes and port mappings to app::
 
     environment_variables = {
         "key1": "val1",
@@ -154,6 +154,13 @@ create app and deploy redis from docker hub::
         persistent_directories=['new-app-redis-data:/data', ]
     )
 
+replace tags on an app::
+
+    cap.update_app(app_name="new-app", tags=["tag1", "tag2"])
+
+clear all tags from an app::
+
+    cap.update_app(app_name="new-app", tags=[])  # set to empty list
 
 delete an app::
 


### PR DESCRIPTION
### Goal
Closes #19

### What I changed

**`deploy_one_click_app`**
- now accepts `tags=` kwarg: a list of strings to tag the new app with
- if you don't pass the optional `tags`, the default is no longer the name of the one-click-app name in the repo, but now it's the app_name you assigned.

**`update_app`**
- explicitly document the `tags=` kwarg.  Tag support was already supported via generic `**kwargs` but now this one is documented.
- change the type of `tags` kwarg from a list of dict, to now a list of str.  More Pythonic.

### What I'm not doing

#19 suggested to "Ability to add tags while _creating_ the app".  That would not follow the pattern of everything else in the API.  Instead one should (and already could) use `api.create_and_update_app("new-app", tags=["tag1"])`
