### PR TITLE
Bump version: 0.1.24 → 0.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,19 @@
 History
 =======
 
+0.2.0 (2025-06-23)
+-------------------
+
+* Allow overriding the entire cap_app_name of a one-click app (#14)
+* BREAKING: Drop namespace parameter for one-click app (#14)
+* Auto-assign tag when deploying one-click app (#14)
+* Override one-click app tag on deploy_one_click_app & update_app (#20)
+* Add projects support (#18)
+
 0.1.24 (2024-12-16)
 -------------------
 
+* Support "command" in service_update_override for one-click apps (#13)
 * Fix & test update from novel kwargs (#12)
 * update method lets you set httpAuth (#11)
 * `update()` now handles persistent directories that use hostPath (#7)

--- a/caprover_api/__init__.py
+++ b/caprover_api/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Akash Agarwal"""
 __email__ = 'agwl.akash@gmail.com'
-__version__ = '0.1.24'
+__version__ = '0.2.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.24
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ak4zh/caprover-api',
-    version='0.1.24',
+    version='0.2.0',
     zip_safe=False,
 )


### PR DESCRIPTION
This includes the latest PRs that were merged after the 0.1.24 release to pypi. See `history.rst`

@ak4zh can you please release 0.2.0 to **pypi**, and it will also require updating **readthedocs**.

