### PR TITLE
Use the path of the "built" one-click repo

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -41,8 +41,7 @@ def retry(times: int, exceptions: tuple = Exception):
     return decorator
 
 
-PUBLIC_ONE_CLICK_APP_PATH = "https://raw.githubusercontent.com/" \
-                                "caprover/one-click-apps/master/public/v4/apps/"
+PUBLIC_ONE_CLICK_APP_PATH = "https://oneclickapps.caprover.com/v4/apps/"
 
 class CaproverAPI:
     class Status:
@@ -132,7 +131,7 @@ class CaproverAPI:
         :return raw_app_definition (str) containing YAML
         """
         raw_app_definition = requests.get(
-            repository_path + one_click_app_name + ".yml"
+            repository_path + one_click_app_name
         ).text
         return raw_app_definition
 


### PR DESCRIPTION
This is for consistency, to match the URL that you'd paste into the CapRover frontend when adding a custom (3rd party) one-click repo

The built repo
- [is built by npm and published on Github Pages](https://github.com/caprover/one-click-apps/?tab=readme-ov-file#build-your-own-one-click-app-repository)
- includes endpoints like https://oneclickapps.caprover.com/v4/list
- does not include the .yml extension on app definitions

Reference:
https://github.com/caprover/caprover/blob/f97e3eedfe63818a21a5f54f4cbd22d216eb5952/src/routes/user/oneclick/OneClickAppRouter.ts#L14