### PR TITLE
Fix crash when calling `create_and_update_app(image_name=...)`

### DIFF
--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -795,7 +795,6 @@ class CaproverAPI:
         if image_name or docker_file_lines:
             response = self.deploy_app(
                 app_name=app_name,
-                project_id=project_id,
                 image_name=image_name,
                 docker_file_lines=docker_file_lines
             )


### PR DESCRIPTION
This fixes a bug introduced in #18, where calling either of
- `create_and_update_app(image_name=...)`
- `create_and_update_app(docker_file_lines=...)`

would raise an unrecoverable TypeError.

The cause/solution is that `CaproverAPI.deploy_app` does **not** accept a `project_id` arg so we should not pass it.