### PR TITLE
DRY: deploy_one_click_app uses create_and_update_app

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.1.25 (2026-07-21)
+-------------------
+
+* Use `create_and_update_app` from `deploy_one_click_app`.
+  This attempts to avoid a rare race condition when `deploy_one_click_app()` calls
+  `update_app` too quickly after `create_app`: `create_and_update_app` includes some sleeps.
+
 0.1.24 (2024-12-16)
 -------------------
 

--- a/caprover_api/__init__.py
+++ b/caprover_api/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Akash Agarwal"""
 __email__ = 'agwl.akash@gmail.com'
-__version__ = '0.1.24'
+__version__ = '0.1.25'

--- a/caprover_api/caprover_api.py
+++ b/caprover_api/caprover_api.py
@@ -419,15 +419,15 @@ class CaproverAPI:
                         service_override_dict, default_style="|"
                     )
 
-                # create app
-                self.create_app(
-                    app_name=service_name,
-                    has_persistent_data=has_persistent_data
-                )
+                image_name = service_data.get("image")
+                docker_file_lines = caprover_extras.get("dockerfileLines")
 
-                # update app
-                self.update_app(
+                # create + update + deploy in one call
+                self.create_and_update_app(
                     app_name=service_name,
+                    has_persistent_data=has_persistent_data,
+                    image_name=image_name,
+                    docker_file_lines=docker_file_lines,
                     instance_count=1,
                     persistent_directories=persistent_directories,
                     environment_variables=environment_variables,
@@ -435,13 +435,6 @@ class CaproverAPI:
                     container_http_port=container_http_port,
                     serviceUpdateOverride=service_update_override,
                     tags=tags,
-                )
-                image_name = service_data.get("image")
-                docker_file_lines = caprover_extras.get("dockerfileLines")
-                self.deploy_app(
-                    service_name,
-                    image_name=image_name,
-                    docker_file_lines=docker_file_lines
                 )
                 apps_deployed.append(service_name)
         return {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.24
+current_version = 0.1.25
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ak4zh/caprover-api',
-    version='0.1.24',
+    version='0.1.25',
     zip_safe=False,
 )


### PR DESCRIPTION
Replaces the separate `create_app/update_app/deploy_app` calls with a single `create_and_update_app` call, making the code more DRY.

No API change or behavior change... other than that we're hoping for a side-effect from `create_and_update_app`'s 0.10s sleeps (which had not been present in `deploy_one_click_app`): 

We intermittently hit CapRover's "No NodeId was found" error (see [caprover/caprover#930](https://github.com/caprover/caprover/issues/930)) between `create_app` and the first `update_app`, specifically when the app uses persistent data. My read from [`ServiceManager.updateAppDefinition`](https://github.com/caprover/caprover/blob/922ed3f/src/user/ServiceManager.ts) is:
1. When `create_app` registers a new app, CapRover appears to spin up a placeholder service for it.
2. `create_app -> _wait_until_app_ready` polls on `isAppBuilding` but not on Swarm's task scheduling, so it can return before the new task has actually been assigned a NodeID.
3. When update_app fires in that gap, the task exists (so CapRover doesn't return "service not found") but NodeID is still empty, hence the error.

The 0.10s sleep isn't a guaranteed fix for this gap, but it happens to sit in the right place, so worth a try.  Even if it doesn't fix "No NodeId was found", this PR is still a simple DRY improvement.